### PR TITLE
Add Notion integration skeleton

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # OliverRocks
+
+This project provides a simple data pool for ingesting unstructured files and producing a cleaned dataset.
+
+## Features
+
+- Ingest CSV, TSV, JSON, XML or plain text files using the `data_pool` package.
+- Normalize keys and remove duplicate records.
+- Command line interface to process files and output cleaned data.
+
+## Usage
+
+Run the CLI by specifying the input file and optional output file:
+
+```bash
+python main.py path/to/input.csv -o cleaned.json
+```
+
+The cleaned data will be written to the specified output file in JSON format. If no output file is given, the result is printed to standard output.
+
+## Tests
+
+To run the test suite:
+
+```bash
+python -m unittest discover tests
+```
+
+## Notion Integration
+
+A preliminary plan for integrating with Notion is available in `docs/notion_plan.md`.
+It outlines how a future `NotionClient` can sync cleaned datasets or project tasks
+to a Notion workspace.

--- a/data_pool/__init__.py
+++ b/data_pool/__init__.py
@@ -1,0 +1,5 @@
+from .ingest import ingest_data
+from .clean import clean_data
+from .notion import NotionClient
+
+__all__ = ['ingest_data', 'clean_data', 'NotionClient']

--- a/data_pool/clean.py
+++ b/data_pool/clean.py
@@ -1,0 +1,27 @@
+from typing import List, Dict
+
+
+def _normalize_keys(data: List[Dict]) -> List[Dict]:
+    normalized = []
+    for item in data:
+        normalized.append({
+            str(k).strip().lower(): str(v).strip() if v is not None else ''
+            for k, v in item.items()
+        })
+    return normalized
+
+
+def _deduplicate(data: List[Dict]) -> List[Dict]:
+    seen = set()
+    result = []
+    for item in data:
+        key = tuple(sorted(item.items()))
+        if key not in seen:
+            seen.add(key)
+            result.append(item)
+    return result
+
+
+def clean_data(data: List[Dict]) -> List[Dict]:
+    """Normalize records and remove duplicates."""
+    return _deduplicate(_normalize_keys(data))

--- a/data_pool/ingest.py
+++ b/data_pool/ingest.py
@@ -1,0 +1,54 @@
+import csv
+import json
+import os
+import xml.etree.ElementTree as ET
+
+
+def _read_csv(path, delimiter=','):
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f, delimiter=delimiter)
+        return [row for row in reader]
+
+
+def _read_json(path):
+    with open(path, encoding='utf-8') as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        return data
+    elif isinstance(data, dict):
+        return [data]
+    else:
+        return [{'value': data}]
+
+
+def _read_xml(path):
+    tree = ET.parse(path)
+    root = tree.getroot()
+    records = []
+    for item in root:
+        record = {}
+        for child in item:
+            record[child.tag] = child.text
+        if record:
+            records.append(record)
+    return records
+
+
+def _read_text(path):
+    with open(path, encoding='utf-8') as f:
+        return [{'value': line.strip()} for line in f if line.strip()]
+
+
+def ingest_data(file_path):
+    """Ingest a data file and return a list of dictionaries."""
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == '.csv':
+        return _read_csv(file_path, delimiter=',')
+    elif ext == '.tsv':
+        return _read_csv(file_path, delimiter='\t')
+    elif ext == '.json':
+        return _read_json(file_path)
+    elif ext == '.xml':
+        return _read_xml(file_path)
+    else:
+        return _read_text(file_path)

--- a/data_pool/notion.py
+++ b/data_pool/notion.py
@@ -1,0 +1,22 @@
+"""Placeholder utilities for Notion API integration.
+
+This module defines a small client skeleton that will later communicate with the
+Notion API. Network operations are not implemented in this offline environment.
+"""
+
+import json
+from typing import Any, Dict
+
+
+class NotionClient:
+    def __init__(self, token: str, database_id: str) -> None:
+        self.token = token
+        self.database_id = database_id
+
+    def create_page(self, data: Dict[str, Any]) -> None:
+        """Create a page in the configured database.
+
+        Raises:
+            NotImplementedError: Always, since the API call is not implemented.
+        """
+        raise NotImplementedError("Notion API integration is not implemented yet")

--- a/docs/notion_plan.md
+++ b/docs/notion_plan.md
@@ -1,0 +1,16 @@
+# Notion Integration Plan
+
+This document outlines initial steps for connecting the data pool project with Notion.
+
+## Goals
+- Track tasks and design notes in a centralized workspace.
+- Eventually push cleaned datasets to a Notion database for review.
+
+## Proposed Steps
+1. Set up a Notion workspace and create a database for project tasks.
+2. Generate an integration token and share the database with it.
+3. Implement a `NotionClient` in `data_pool/notion.py` to communicate with the API.
+4. Use `urllib.request` for HTTP operations to avoid external dependencies.
+5. Add unit tests with mocks to validate request payloads without requiring network access.
+
+Further details will be fleshed out as development progresses.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,23 @@
+import argparse
+import json
+from data_pool import ingest_data, clean_data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ingest and clean data files")
+    parser.add_argument("input_file", help="Path to the input data file")
+    parser.add_argument("-o", "--output", help="Optional path to write cleaned data")
+    args = parser.parse_args()
+
+    data = ingest_data(args.input_file)
+    cleaned = clean_data(data)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(cleaned, f, indent=2)
+    else:
+        print(json.dumps(cleaned, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ingest_clean.py
+++ b/tests/test_ingest_clean.py
@@ -1,0 +1,34 @@
+import json
+import os
+import unittest
+
+from data_pool import ingest_data, clean_data
+
+
+class TestIngestClean(unittest.TestCase):
+    def setUp(self):
+        self.csv_file = "sample.csv"
+        with open(self.csv_file, "w", newline='', encoding='utf-8') as f:
+            f.write("id,name\n1,Alice\n2,Bob\n")
+
+        self.json_file = "sample.json"
+        with open(self.json_file, "w", encoding='utf-8') as f:
+            json.dump([{"id": "1", "name": "Alice"}, {"id": "1", "name": "Alice"}], f)
+
+    def tearDown(self):
+        os.remove(self.csv_file)
+        os.remove(self.json_file)
+
+    def test_ingest_csv(self):
+        data = ingest_data(self.csv_file)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["id"], "1")
+
+    def test_clean_data(self):
+        data = ingest_data(self.json_file)
+        cleaned = clean_data(data)
+        self.assertEqual(len(cleaned), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -1,0 +1,13 @@
+import unittest
+from data_pool.notion import NotionClient
+
+
+class TestNotionClient(unittest.TestCase):
+    def test_create_page_not_implemented(self):
+        client = NotionClient(token="token", database_id="db")
+        with self.assertRaises(NotImplementedError):
+            client.create_page({"field": "value"})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a basic plan in `docs/notion_plan.md`
- include a placeholder `NotionClient` class
- expose `NotionClient` in the package
- document Notion plans in the README
- test that `NotionClient.create_page` is not implemented

## Testing
- `python -m unittest discover tests`
